### PR TITLE
Adding`git-branch` as input option to allow for `deployment_status` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Basic usage:
   with:
     supabase-access-token: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
     supabase-project-id: ${{ secrets.SUPABASE_PROJECT_ID }}
+    git-branch: "sb-preview-branch" # Optional
     wait-for-migrations: true # Optional. Default is false.
     timeout: 60 # Optional. Default is 60.
 - name: Get result

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   supabase-project-id:
     description: The Supabase Project ID with database branching enabled.
     required: true
+  git-branch:
+    description: The name of the Github branch to wait for.
+    required: false
   wait-for-migrations:
     description: Whether to wait for migrations to be applied before returning the branch.
     default: "false"


### PR DESCRIPTION
**Summary:**
This PR adds a new input option called `git-branch` to our GitHub Action. This enhancement is necessary for handling `deployment_status` events, as these events do not provide the `GITHUB_HEAD_REF` or `GITHUB_REF` environment variables.

**Details:**
- Introduced a `git-branch` input option.
- This input allows specifying the branch name explicitly when triggered by `deployment_status` events.
- Ensures the action can correctly identify the branch and proceed with the deployment process.

**Reason:**
`deployment_status` events lack the `GITHUB_HEAD_REF` and `GITHUB_REF` environment variables, which are typically used to determine the branch. Adding this input option ensures that our action can handle these events properly without missing the branch context.